### PR TITLE
Make SRID configurable per topic source

### DIFF
--- a/.env
+++ b/.env
@@ -7,7 +7,6 @@ geospatial_analyzer_db_password: geobakery
 geospatial_analyzer_db_database: postgres
 geospatial_analyzer_db_synchronize: false
 geospatial_analyzer_db_logging: true
-geospatial_analyzer_srid: 25833
 #extras
 geospatial_analyzer_connectTimeoutMS: 60000
 geospatial_analyzer_statement_timeout: 30000

--- a/.env.test
+++ b/.env.test
@@ -7,4 +7,3 @@ geospatial_analyzer_db_password: geobakery
 geospatial_analyzer_db_database: postgres
 geospatial_analyzer_db_synchronize: false
 geospatial_analyzer_db_logging: true
-geospatial_analyzer_srid: 25833

--- a/documentation/enviroment.md
+++ b/documentation/enviroment.md
@@ -10,14 +10,22 @@ TODO: Complete documentation
     "identifiers": ["verw_land_f"],
     "title": "Verwaltung Landkreise",
     "description": "analyzes federal states and neighbouring states.",
-    "__source__": "spatialyzer_demo.verw_land_f",
+    "__source__": {
+      "name": "unused",
+      "source": "spatialyzer_demo.verw_land_f",
+      "srid": 25833
+    },
     "__attributes__": ["id00", "name", "bundesland", "geom"],
     "__supports__": ["intersect","within", "nearestNeighbour"]
   },{
     "identifiers": ["hoehe2m_r"],
     "title": "Höhenwerte für Dresden",
     "description": "Contains information on terrain elevation and surface elevation in Saxony.",
-    "__source__": "spatialyzer_demo.hoehe2m_r",
+    "__source__": {
+        "name": "unused",
+        "source": "spatialyzer_demo.hoehe2m_r",
+        "srid": 25833
+    },
     "__attributes__": [],
     "__supports__": ["valuesAtPoint"]
   }

--- a/src/general/general.interface.ts
+++ b/src/general/general.interface.ts
@@ -13,15 +13,13 @@ export interface DBResponse {
   id: string;
 }
 
-export interface topicDefinition {
+export type topicDefinition = {
   identifiers: string[];
   title: string;
   description?: string;
-  __source__: string;
   __attributes__?: string[];
   __supports__?: string[];
-  __multipleSources__?: multipleSource[];
-}
+} & ({ __source__: Source } | { __multipleSources__: Source[] });
 
 export interface topicDefinitionOutside {
   identifiers: string[];
@@ -43,9 +41,13 @@ export interface tempResult {
   id: string;
 }
 
-export interface multipleSource {
+export interface Source {
+  /** The (possibly schema-qualified) name of the database relation. */
   source: string;
+  /** A human-readable name to identify the source by. */
   name: string;
+  /** The spatial reference system identifier used by this source. */
+  srid: number;
 }
 
 export interface SqlLiteral {

--- a/src/values-at-point/values-at-point.service.ts
+++ b/src/values-at-point/values-at-point.service.ts
@@ -49,11 +49,13 @@ export class ValuesAtPointService extends GeospatialService<ParameterDto> {
     for (const [sourceIndex, source] of sources.entries()) {
       const featureValue = this.getValueArRasterString(
         queryBuilder,
+        source.srid,
         feature,
         featureIndex,
       );
       const featureIntersect = this.getFeatureIntersectString(
         queryBuilder,
+        source.srid,
         feature,
         featureIndex,
       );
@@ -87,6 +89,7 @@ export class ValuesAtPointService extends GeospatialService<ParameterDto> {
   }
   private getValueArRasterString(
     queryStart: SelectQueryBuilder<unknown>,
+    srid: number,
     feature: GeoJSONFeatureDto,
     featureIndex: number,
   ): string {
@@ -97,7 +100,7 @@ export class ValuesAtPointService extends GeospatialService<ParameterDto> {
     );
     const queryFeature = this.adapter.transformFeature(
       { raw: true, value: `:${QUERY_FEATURE_INDEX}${featureIndex}` },
-      this.generalService.database_srid,
+      srid,
     );
     const dbFeature = 'rast';
 
@@ -110,6 +113,7 @@ export class ValuesAtPointService extends GeospatialService<ParameterDto> {
 
   private getFeatureIntersectString(
     queryStart: SelectQueryBuilder<unknown>,
+    srid: number,
     feature: GeoJSONFeatureDto,
     featureIndex: number,
   ): string {
@@ -120,7 +124,7 @@ export class ValuesAtPointService extends GeospatialService<ParameterDto> {
     );
     const queryFeature = this.adapter.transformFeature(
       { raw: true, value: `:${QUERY_FEATURE_INDEX}${featureIndex}` },
-      this.generalService.database_srid,
+      srid,
     );
     const dbFeature = 'rast';
 

--- a/topic-example-geosn.json
+++ b/topic-example-geosn.json
@@ -4,7 +4,11 @@
       "identifiers": ["verw_land_f"],
       "title": "Verwaltung Landkreise",
       "description": "analyzes federal states and neighbouring states.",
-      "__source__": "spatialyzer_demo.verw_land_f",
+      "__source__": {
+        "name": "unused",
+        "source": "spatialyzer_demo.verw_land_f",
+        "srid": 25833
+      },
       "__attributes__": ["bundesland","egm_code", "id", "land", "name", "nuts_code", "geometrieflaeche", "geometrieflaeche_eh"],
       "__supports__": ["intersect", "within", "nearestNeighbour"]
     },
@@ -15,7 +19,11 @@
       ],
       "title": "Verwaltung Kreise",
       "description": "analyzes the districts in Saxony.",
-      "__source__": "spatialyzer_demo.verw_kreis_f",
+      "__source__": {
+        "name": "unused",
+        "source": "spatialyzer_demo.verw_kreis_f",
+        "srid": 25833
+      },
       "__attributes__": ["country", "country_cl", "id_localid", "id_namespace", "ifcid", "name", "nationalcode", "nationallevel", "nationallevel_cl", "upperlevelunit", "geometrieflaeche", "geometrieflaeche_eh"],
       "__supports__": ["intersect", "within", "nearestNeighbour"]
     },
@@ -25,12 +33,14 @@
       "description": "Contains information on terrain elevation and surface elevation in Saxony.",
       "__multipleSources__": [
         {
+          "name": "dgm_height",
           "source": "spatialyzer_demo.hoehe2m_r",
-          "name": "dgm_height"
+          "srid": 25833
         },
         {
+          "name": "dom_height",
           "source":  "spatialyzer_demo.hoehe2m_dom_r",
-          "name": "dom_height"
+          "srid": 25833
         }
       ],
       "__attributes__": [],
@@ -42,7 +52,11 @@
       "identifiers": ["verw_gem_f"],
       "title": "Verwaltung Gemeinden",
       "description": "analyzes the municipalities in Saxony.",
-      "__source__": "spatialyzer_demo.verw_gem_f",
+      "__source__": {
+        "name": "unused",
+        "source": "spatialyzer_demo.verw_gem_f",
+        "srid": 25833
+      },
       "__attributes__": ["country", "country_cl", "id_localid", "id_namespace", "ifcid", "name", "nationalcode", "nationallevel", "nationallevel_cl", "upperlevelunit", "geometrieflaeche", "geometrieflaeche_eh"],
       "__supports__": ["intersect", "within", "nearestNeighbour"]
     },
@@ -50,7 +64,11 @@
       "identifiers": ["umw_wassersch_f"],
       "title": "Wasserschutz",
       "description": "analyzes water protection areas inm Saxony.",
-      "__source__": "spatialyzer_demo.umw_wassersch_f",
+      "__source__": {
+        "name": "unused",
+        "source": "spatialyzer_demo.umw_wassersch_f",
+        "srid": 25833
+      },
       "__attributes__": ["datenstand", "ezg", "flaeche_in_ha", "gml_id", "inkrafttreten", "landesdirektion", "landkreis", "name", "nummer", "teilzone", "typ", "zone", "geometrieflaeche", "geometrieflaeche_eh"],
       "__supports__": ["intersect", "within", "nearestNeighbour"]
     },
@@ -58,7 +76,11 @@
       "identifiers": ["umw_nat2000_f"],
       "title": "Nat2000 Fläche",
       "description": "analyzes Fauna-Flora-Habitat areas in Saxony.",
-      "__source__": "spatialyzer_demo.umw_nat2000_f",
+      "__source__": {
+        "name": "unused",
+        "source": "spatialyzer_demo.umw_nat2000_f",
+        "srid": 25833
+      },
       "__attributes__": ["erfassung", "eu_nr", "gebiet", "gml_id", "info", "legende", "meldeflaec", "sn_nr", "teilfl", "typ", "rechts_gl", "geometrieflaeche", "geometrieflaeche_eh"],
       "__supports__": ["intersect", "within", "nearestNeighbour"]
     },
@@ -66,7 +88,11 @@
       "identifiers": ["umw_nat2000_p"],
       "title": "Nat2000 Punkte",
       "description": "analyzes bat roosts in Saxony.",
-      "__source__": "spatialyzer_demo.umw_nat2000_p",
+      "__source__": {
+        "name": "unused",
+        "source": "spatialyzer_demo.umw_nat2000_p",
+        "srid": 25833
+      },
       "__attributes__": ["erfassung", "eu_nr", "gebiet", "gml_id", "info", "legende", "meldeflaec", "sn_nr", "teilfl", "typ"],
       "__supports__": ["intersect", "nearestNeighbour"]
     },
@@ -74,7 +100,11 @@
       "identifiers": ["umw_schutzgeb_f"],
       "title": "Umweltschutzgebiete",
       "description": "analyzes nature reserves in Saxony.",
-      "__source__": "spatialyzer_demo.umw_schutzgeb_f",
+      "__source__": {
+        "name": "unused",
+        "source": "spatialyzer_demo.umw_schutzgeb_f",
+        "srid": 25833
+      },
       "__attributes__": ["erfdat", "gml_id", "id_zo", "kategorie", "name", "praezi", "sg_nr", "status", "teilarea", "typ", "uebdat", "zone", "geometrieflaeche", "geometrieflaeche_eh"],
       "__supports__": ["intersect", "within", "nearestNeighbour"]
     },
@@ -82,7 +112,11 @@
       "identifiers": ["geol_hohlraumbas_f"],
       "title": "Hohlraum",
       "description": "analyzes cavities in Saxony (underground cavities that are subject to the scope of the Federal Mining Act, areas with mine workings under mining supervision).",
-      "__source__": "spatialyzer_demo.geol_hohlraumbas_f",
+      "__source__": {
+        "name": "unused",
+        "source": "spatialyzer_demo.geol_hohlraumbas_f",
+        "srid": 25833
+      },
       "__attributes__": ["objectid", "perimeter", "geometrieflaeche", "geometrieflaeche_eh"],
       "__supports__": ["intersect", "within", "nearestNeighbour"]
     },
@@ -90,7 +124,11 @@
       "identifiers": ["geol_hohlraumuih_f"],
       "title": "Holraum",
       "description": "analyzes cavities in Saxony (areas where underground cavities are to be expected or known).",
-      "__source__": "spatialyzer_demo.geol_hohlraumuih_f",
+      "__source__": {
+        "name": "unused",
+        "source": "spatialyzer_demo.geol_hohlraumuih_f",
+        "srid": 25833
+      },
       "__attributes__": ["id_geom_re", "bufferval", "idart_list", "geometrieflaeche", "geometrieflaeche_eh"],
       "__supports__": ["intersect", "within", "nearestNeighbour"]
     },
@@ -98,7 +136,11 @@
       "identifiers": ["adressen_p"],
       "title": "Adressen Sachsen",
       "description": "analyzes addresses in Saxony.",
-      "__source__": "spatialyzer_demo.adressen_p",
+      "__source__": {
+        "name": "unused",
+        "source": "spatialyzer_demo.adressen_p",
+        "srid": 25833
+      },
       "__attributes__": ["strasse", "str_nummer", "plz", "ort"],
       "__supports__": ["intersect", "nearestNeighbour"]
     },
@@ -106,7 +148,11 @@
       "identifiers": ["gesu_aspsz_f"],
       "title": "Afrikanische Schweinepest",
       "description": "analyzes exclusion zones due to findings of african swine fever.",
-      "__source__": "spatialyzer_demo.gesu_aspsz_f",
+      "__source__": {
+        "name": "unused",
+        "source": "spatialyzer_demo.gesu_aspsz_f",
+        "srid": 25833
+      },
       "__attributes__": ["name"],
       "__supports__": ["intersect", "within", "nearestNeighbour"]
     },
@@ -114,7 +160,11 @@
       "identifiers": ["kat_gemark_f"],
       "title": "Gemarkungen",
       "description": "analyzes the districts in Saxony.",
-      "__source__": "spatialyzer_demo.kat_gemark_f",
+      "__source__": {
+        "name": "unused",
+        "source": "spatialyzer_demo.kat_gemark_f",
+        "srid": 25833
+      },
       "__attributes__": ["id_localid", "id_namespace", "ifcid", "level_", "level_cl", "name", "schluessel", "nationalcadastalzoningref", "geometrieflaeche", "geometrieflaeche_eh"],
       "__supports__": ["intersect", "within", "nearestNeighbour"]
     },
@@ -122,7 +172,11 @@
       "identifiers": ["kat_flurst_f"],
       "title": "Flurstücke",
       "description": "analyzes the parcels in Saxony.",
-      "__source__": "spatialyzer_demo.kat_flurst_f",
+      "__source__": {
+        "name": "unused",
+        "source": "spatialyzer_demo.kat_flurst_f",
+        "srid": 25833
+      },
       "__attributes__": ["admunit", "areavalue", "areavalue_uom", "gemarkung_name", "id_localid", "id_namespace", "ifcid", "label", "nationalcadastralref", "zoning", "geometrieflaeche", "geometrieflaeche_eh"],
       "__supports__": ["intersect", "within", "nearestNeighbour"]
     },
@@ -130,7 +184,11 @@
       "identifiers": ["efa/thueringen"],
       "title": "EfA Thüringen",
       "description": "EfA Thüringen",
-      "__source__": "efa.thueringen",
+      "__source__": {
+        "name": "unused",
+        "source": "efa.thueringen",
+        "srid": 25833
+      },
       "__attributes__": ["name", "nationalcode", "geometrieflaeche", "geometrieflaeche_eh"],
       "__supports__": ["intersect", "within", "nearestNeighbour"]
     }

--- a/topic-example.json
+++ b/topic-example.json
@@ -7,7 +7,11 @@
       ],
       "title": "User adress", // title for end user
       "description": "lists the addresses of all user.", // description for end user
-      "__source__": "schmema.table_adress", // database source [not published for end user]
+      "__source__": { // database source [not published for end user]
+        "name": "unused",
+        "source": "schmema.table_adress",
+        "srid": 4326
+      },
       "__attributes__": [ // attributes to show for the end user [not published for end user]
         "title",
         "name",


### PR DESCRIPTION
Previously, we assumed a uniform SRID for the whole database. Now, each tables can have independent SRIDs from each other.

Addresses the final task of #21 