### PR TITLE
feat/github action image building workflow improvements

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -38,7 +38,7 @@ jobs:
           tags: |
             type=sha,enable={{is_default_branch}}                                           # main branch -> tag: `sha-{git-commit-hash}`
             type=ref,event=pr,suffix={{sha}}                                                # pull_requests -> tag: `pr-{git-commit-hash}`
-            type=ref,event=branch,suffix={{sha}},enable=${{github.event_name == 'workflow_dispatch'}}    # manual builds -> tag: `{branch}-{git-commit-hash}`
+            type=ref,event=branch,suffix=-{{sha}},enable=${{github.event_name == 'workflow_dispatch'}}    # manual builds -> tag: `{branch}-{git-commit-hash}`
             type=semver,pattern={{version}}                                                 # git tag with semver format -> docker tag: `{version}` (e.g. 1.2.3)
 
       - name: Build and push image


### PR DESCRIPTION
A) Rework docker image tagging to differentiate source of builds and use cases:
- pull request builds -> `pr-{sha}` -> for development/testing
- updates to main -> `sha-{sha}` -> latest / immutable build of the app, independent of releases
- (tagged version stays the same -> `{version}`) -> stable releases
- manual builds -> `{branch}-{sha}` -> different use cases

B) dependabot update branches are not built automatically to avoid cluttering the container registry