### PR TITLE
fix: adjust e2e tests for new data

### DIFF
--- a/test/intersect.e2e-spec.ts
+++ b/test/intersect.e2e-spec.ts
@@ -259,7 +259,7 @@ describe('IntersectController (e2e)', () => {
     expect(singleCoordinate[0]).toBeGreaterThan(13);
     expect(singleCoordinate[0]).toBeLessThan(14);
     expect(singleCoordinate[1]).toBeGreaterThan(50);
-    expect(singleCoordinate[1]).toBeLessThan(51);
+    expect(singleCoordinate[1]).toBeLessThan(52);
   });
 
   it('/POST Intersect with esri input and output', async () => {
@@ -368,7 +368,7 @@ describe('IntersectController (e2e)', () => {
     expect(singleCoordinate[0]).toBeGreaterThan(13);
     expect(singleCoordinate[0]).toBeLessThan(14);
     expect(singleCoordinate[1]).toBeGreaterThan(50);
-    expect(singleCoordinate[1]).toBeLessThan(51);
+    expect(singleCoordinate[1]).toBeLessThan(52);
   });
 
   it(`should reject GeoJSON output with any SRS other than WGS 84`, async () => {

--- a/test/values-at-point.e2e-spec.ts
+++ b/test/values-at-point.e2e-spec.ts
@@ -113,7 +113,7 @@ describe('ValuesAtPointController (e2e)', () => {
     expect(heightsGeoJSON.type).toBe('Feature');
 
     const props = heightsGeoJSON.properties;
-    expect(props['__name']).toBe('gelaendehoehe_dgm2');
+    expect(props['__name']).toBe('gelaendehoehe_dgm');
     expect(props['__topic']).toBe('hoehe_r');
     expect(props['height']).toBe(24886);
 
@@ -131,7 +131,7 @@ describe('ValuesAtPointController (e2e)', () => {
     expect(domGeoJSON.type).toBe('Feature');
 
     const propsLand = domGeoJSON.properties;
-    expect(propsLand['__name']).toBe('oberflaechenhoehe_dom2');
+    expect(propsLand['__name']).toBe('oberflaechenhoehe_dom');
     expect(propsLand['__topic']).toBe('hoehe_r');
     expect(propsLand['height']).toBe(24886);
 


### PR DESCRIPTION
This PR updates the E2E tests to align with the new data and schema changes.