### PR TITLE
feat: convert raster height values to meter

### DIFF
--- a/test/values-at-point.e2e-spec.ts
+++ b/test/values-at-point.e2e-spec.ts
@@ -115,7 +115,7 @@ describe('ValuesAtPointController (e2e)', () => {
     const props = heightsGeoJSON.properties;
     expect(props['__name']).toBe('gelaendehoehe_dgm');
     expect(props['__topic']).toBe('hoehe_r');
-    expect(props['height']).toBe(24886);
+    expect(props['height']).toBe(248.86);
 
     const geoProps = props['__geoProperties'];
     const requestProps = props['__requestParams'];
@@ -133,7 +133,7 @@ describe('ValuesAtPointController (e2e)', () => {
     const propsLand = domGeoJSON.properties;
     expect(propsLand['__name']).toBe('oberflaechenhoehe_dom');
     expect(propsLand['__topic']).toBe('hoehe_r');
-    expect(propsLand['height']).toBe(24886);
+    expect(propsLand['height']).toBe(248.86);
 
     const geoPropsLand = propsLand['__geoProperties'];
     const requestPropsLand = propsLand['__requestParams'];

--- a/topic.json
+++ b/topic.json
@@ -63,7 +63,7 @@
       ],
       "__attributes__": [],
       "__valueMetadata__": {
-        "unit": "cm",
+        "unit": "m",
         "verticalDatum": "DHHN2016"
       },
       "__supports__": ["valuesAtPoint"],


### PR DESCRIPTION
- Affected tables: ga.dgm_r, ga.dom_r
- Elevation values are now stored as floating-point numbers and displayed in meters
- The production data has been prepared and will be migrated with the new deployment