### PR TITLE
feat(topics): add provider attribution and expose value metadata

### DIFF
--- a/documentation/topics.md
+++ b/documentation/topics.md
@@ -1,8 +1,30 @@
 # Topics - API Call
+
 In this document we will describe important and good-to-know facts about the topics service.
 
 ## Functionality
-Show all topics.
+
+Show all topics along with their metadata: `identifiers`, `title`, `description`, the list of supported operations (`supports`), available `attributes`, and if present `valueMetadata` and `attribution`.
 
 ## Examples
-Get-call http://localhost:3000/v1/topics  
+
+Get-call http://localhost:3000/v1/topics
+
+## Optional topic metadata
+
+Topics may carry two optional blocks that appear in the `/topics` response when configured in `topic.json`:
+
+- `valueMetadata` — unit and vertical datum for topic values. Topic-wide defaults at the top with per-source overrides in an optional `sources[]`. Shape: `{ unit?, verticalDatum?, sources?: [{ sourceName, unit?, verticalDatum? }] }`. See [valuesAtPoint.md](./valuesAtPoint.md#value-metadata-in-responses).
+- `attribution` — list of data providers for the dataset(s). Each entry has optional `name` and `url`. For multi-source topics the response is the de-duplicated union of what each source contributes (with topic-level fallback for sources that have no own attribution). Omitted entirely when nothing is configured. Source-specific attribution is available on feature responses via `__attribution`.
+
+  ```json
+  [
+    { "name": "GeoSN", "url": "https://example.org/dataset-dgm" },
+    { "name": "GeoSN", "url": "https://example.org/dataset-dom" }
+  ]
+  ```
+
+### Configuration in `topic.json`
+
+- Topic-level: add `__attribution__: [{ name?, url? }, ...]` on the topic.
+- Per-source: add `attribution: [{ name?, url? }, ...]` on a `__source__` or any entry of `__multipleSources__`. A source-level list fully replaces the topic-level list for that source.

--- a/src/general/dto/topic-definition-outside.dto.ts
+++ b/src/general/dto/topic-definition-outside.dto.ts
@@ -29,7 +29,15 @@ export class TopicDefinitionOutsideDto {
     example: { unit: 'm', verticalDatum: 'DHHN2016' },
     required: false,
     description:
-      'Unit and vertical datum at topic level. Used as fallback when individual sources do not provide their own metadata.',
+      'Unit and vertical datum for topic values. Top-level `unit` / `verticalDatum` are topic-wide defaults. For topics with multiple sources, per-source overrides appear in `sources[]` keyed by `sourceName` (matches the `__name` property in feature responses). Per-entry fields override the topic-level defaults field-by-field. All fields are independently optional.',
   })
-  __valueMetadata__?: { unit?: string; verticalDatum?: string };
+  valueMetadata?: {
+    unit?: string;
+    verticalDatum?: string;
+    sources?: Array<{
+      sourceName: string;
+      unit?: string;
+      verticalDatum?: string;
+    }>;
+  };
 }

--- a/src/general/dto/topic-definition-outside.dto.ts
+++ b/src/general/dto/topic-definition-outside.dto.ts
@@ -1,14 +1,14 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class TopicDefinitionOutsideDto {
-  @ApiProperty({ example: ['verwaltung_landkreise_id'] })
+  @ApiProperty({ example: ['sn_kreis_f', 'kreis_f'] })
   identifiers: string[];
 
-  @ApiProperty({ example: 'Verwaltung Landkreise' })
+  @ApiProperty({ example: 'Landkreise/Kreise' })
   title: string;
 
   @ApiProperty({
-    example: 'Verwaltung der Landkreise in Sachsen',
+    example: 'Landkreise und kreisfreie Städte in Sachsen.',
     required: false,
   })
   description?: string;
@@ -26,7 +26,6 @@ export class TopicDefinitionOutsideDto {
   attributes?: string[];
 
   @ApiPropertyOptional({
-    example: { unit: 'm', verticalDatum: 'DHHN2016' },
     required: false,
     description:
       'Unit and vertical datum for topic values. Top-level `unit` / `verticalDatum` are topic-wide defaults. For topics with multiple sources, per-source overrides appear in `sources[]` keyed by `sourceName` (matches the `__name` property in feature responses). Per-entry fields override the topic-level defaults field-by-field. All fields are independently optional.',
@@ -40,4 +39,12 @@ export class TopicDefinitionOutsideDto {
       verticalDatum?: string;
     }>;
   };
+
+  @ApiPropertyOptional({
+    example: [{ name: 'GeoSN' }],
+    required: false,
+    description:
+      'Attribution for the data source(s). A de-duplicated list of data providers used by this topic, each with optional `name` and `url`. For topics with multiple sources, entries are unioned across all sources. Source-specific attribution is additionally available on feature responses via the `__attribution` property.',
+  })
+  attribution?: Array<{ name?: string; url?: string }>;
 }

--- a/src/general/general.interface.ts
+++ b/src/general/general.interface.ts
@@ -38,6 +38,15 @@ export interface topicDefinitionOutside {
   description?: string;
   supports?: string[];
   attributes?: string[];
+  valueMetadata?: {
+    unit?: string;
+    verticalDatum?: string;
+    sources?: Array<{
+      sourceName: string;
+      unit?: string;
+      verticalDatum?: string;
+    }>;
+  };
 }
 
 export interface SupportedTopics {

--- a/src/general/general.interface.ts
+++ b/src/general/general.interface.ts
@@ -30,6 +30,8 @@ export type topicDefinition = {
     unit?: string;
     verticalDatum?: string;
   };
+  /** Optional per-topic attribution (list of data providers) */
+  __attribution__?: Array<{ name?: string; url?: string }>;
 } & ({ __source__: Source } | { __multipleSources__: Source[] });
 
 export interface topicDefinitionOutside {
@@ -47,6 +49,7 @@ export interface topicDefinitionOutside {
       verticalDatum?: string;
     }>;
   };
+  attribution?: Array<{ name?: string; url?: string }>;
 }
 
 export interface SupportedTopics {
@@ -72,6 +75,8 @@ export type SpatialMetadata = Partial<{
   /** Optional value metadata exposed directly on feature properties */
   __unit?: string;
   __verticalDatum?: string;
+  /** Optional attribution exposed directly on feature properties */
+  __attribution?: Array<{ name?: string; url?: string }>;
 }>;
 
 export interface Source {
@@ -85,6 +90,8 @@ export interface Source {
   unit?: string;
   /** Optional per-source vertical datum (e.g. "DHHN2016") */
   verticalDatum?: string;
+  /** Optional per-source attribution (replaces topic-level list for this source) */
+  attribution?: Array<{ name?: string; url?: string }>;
 }
 
 export interface SqlLiteral {

--- a/src/general/general.service.ts
+++ b/src/general/general.service.ts
@@ -93,6 +93,70 @@ export class GeneralService {
       .map((groupName) => groupName.trim());
   }
 
+  /**
+   * Returns a copy of the object with undefined/empty-string fields stripped,
+   * or undefined if no fields remain. Used to omit optional metadata objects
+   * entirely when none of their sub-fields are filled.
+   */
+  private _normalizeOptionalObject<T extends Record<string, unknown>>(
+    obj: T | undefined | null,
+  ): Partial<T> | undefined {
+    if (!obj) return undefined;
+    const result: Partial<T> = {};
+    let hasValue = false;
+    for (const [key, value] of Object.entries(obj)) {
+      if (value !== undefined && value !== null && value !== '') {
+        (result as Record<string, unknown>)[key] = value;
+        hasValue = true;
+      }
+    }
+    return hasValue ? result : undefined;
+  }
+
+  /**
+   * Build a unified metadata section output for /topics responses.
+   * Single-source topics merge topic-level + source-level into a flat object
+   * (source overrides per field). Multi-source topics keep topic-level at the
+   * top and add a sources[] array with one entry per source that carries its
+   * own values.
+   */
+  private _buildOutputMetadataSection<T extends Record<string, string>>(
+    t: topicDefinition,
+    getTopicLevel: (topic: topicDefinition) => Partial<T> | undefined,
+    getSourceLevel: (source: Source) => Partial<T> | undefined,
+  ):
+    | (Partial<T> & { sources?: Array<{ sourceName: string } & Partial<T>> })
+    | undefined {
+    const topicLevel = this._normalizeOptionalObject(getTopicLevel(t)) ?? {};
+
+    if ('__source__' in t) {
+      const sourceLevel =
+        this._normalizeOptionalObject(getSourceLevel(t.__source__)) ?? {};
+      const merged = { ...topicLevel, ...sourceLevel } as Partial<T>;
+      return Object.keys(merged).length ? merged : undefined;
+    }
+
+    if ('__multipleSources__' in t) {
+      const sourceEntries = t.__multipleSources__
+        .map((s) => {
+          const own = this._normalizeOptionalObject(getSourceLevel(s));
+          if (!own) return undefined;
+          return { sourceName: s.name, ...own } as {
+            sourceName: string;
+          } & Partial<T>;
+        })
+        .filter((e): e is { sourceName: string } & Partial<T> => Boolean(e));
+
+      const out: Partial<T> & {
+        sources?: Array<{ sourceName: string } & Partial<T>>;
+      } = { ...topicLevel };
+      if (sourceEntries.length) out.sources = sourceEntries;
+      return Object.keys(out).length ? out : undefined;
+    }
+
+    return undefined;
+  }
+
   private isObject(x: unknown): x is object {
     try {
       return '' in (x as object) || true;
@@ -200,13 +264,25 @@ export class GeneralService {
     td.forEach((t) => {
       if (!this._doesTopicMatchGroupFilter(t)) return;
 
-      const definition = {
+      const definition: topicDefinitionOutside = {
         identifiers: t.identifiers,
         title: t.title,
         description: t.description,
         supports: t.__supports__,
         attributes: t.__attributes__ ?? [],
-      } as topicDefinitionOutside;
+      };
+
+      const valueMetadata = this._buildOutputMetadataSection(
+        t,
+        (topic) => topic.__valueMetadata__,
+        (source) => ({
+          unit: source.unit,
+          verticalDatum: source.verticalDatum,
+        }),
+      );
+      if (valueMetadata) {
+        definition.valueMetadata = valueMetadata;
+      }
 
       if (!this.uniqueTopicsMap.has(t.title)) {
         this.uniqueTopicsMap.set(t.title, definition);
@@ -234,7 +310,9 @@ export class GeneralService {
         }
 
         // store per-topic value metadata (fallback) if present
-        const topicValueMetadata = (t as topicDefinition).__valueMetadata__;
+        const topicValueMetadata = this._normalizeOptionalObject(
+          (t as topicDefinition).__valueMetadata__,
+        );
         if (topicValueMetadata) {
           this.identifierValueMetadataMap.set(identifier, topicValueMetadata);
         }
@@ -379,33 +457,20 @@ export class GeneralService {
           feature.properties.__geoProperties = map.get(result.id);
           feature.properties.__topic = result.topic;
 
-          // attach value metadata: start with topic-level fallback, then override with per-source metadata if present
-          let valueMetadata = this.identifierValueMetadataMap.get(result.topic);
-
           const sourceName = (feature.properties as any)[
             SOURCE_NAME_PROPERTY
           ] as string | undefined;
-          if (sourceName) {
-            const sources = this.getMultipleDBNamesForIdentifier(result.topic);
-            if (Array.isArray(sources) && sources.length) {
-              const source = sources.find((s) => s.name === sourceName);
-              if (source && (source.unit || source.verticalDatum)) {
-                valueMetadata = {
-                  unit: source.unit,
-                  verticalDatum: source.verticalDatum,
-                };
-              }
-            }
-          }
+          const source = this._resolveSource(result.topic, sourceName);
 
-          if (valueMetadata) {
-            if (!feature.properties) feature.properties = {} as any;
-            if (valueMetadata.unit)
-              (feature.properties as any).__unit = valueMetadata.unit;
-            if (valueMetadata.verticalDatum)
-              (feature.properties as any).__verticalDatum =
-                valueMetadata.verticalDatum;
-          }
+          // merge per field: source override wins, topic-level is fallback
+          const topicValueMetadata =
+            this.identifierValueMetadataMap.get(result.topic) ?? {};
+          const unit = source?.unit ?? topicValueMetadata.unit;
+          const verticalDatum =
+            source?.verticalDatum ?? topicValueMetadata.verticalDatum;
+          if (unit) (feature.properties as any).__unit = unit;
+          if (verticalDatum)
+            (feature.properties as any).__verticalDatum = verticalDatum;
         });
       }
     });
@@ -417,6 +482,17 @@ export class GeneralService {
 
   getMultipleDBNamesForIdentifier(top: string): Source[] {
     return this.identifierMultipleSourcesMap.get(top) ?? [];
+  }
+
+  private _resolveSource(
+    topic: string,
+    sourceName: string | undefined,
+  ): Source | undefined {
+    const multi = this.getMultipleDBNamesForIdentifier(topic);
+    if (multi.length) {
+      return sourceName ? multi.find((s) => s.name === sourceName) : undefined;
+    }
+    return this.getSourceForIdentifier(topic);
   }
 
   prepareDBResponse(

--- a/src/general/general.service.ts
+++ b/src/general/general.service.ts
@@ -53,6 +53,10 @@ export class GeneralService {
     string,
     { unit?: string; verticalDatum?: string }
   > = new Map();
+  identifierAttributionMap: Map<
+    string,
+    Array<{ name?: string; url?: string }>
+  > = new Map();
   methodeTopicSupport: SupportedTopics = {
     intersect: [],
     within: [],
@@ -155,6 +159,37 @@ export class GeneralService {
     }
 
     return undefined;
+  }
+
+  /**
+   * Collect the attribution list for a /topics response.
+   * Produces a de-duplicated union of provider entries across all sources
+   * (falling back to the topic-level list when a source has none).
+   */
+  private _collectAttribution(
+    t: topicDefinition,
+  ): Array<{ name?: string; url?: string }> | undefined {
+    const topicLevel = t.__attribution__ ?? [];
+    const sources: Source[] =
+      '__source__' in t
+        ? [t.__source__]
+        : '__multipleSources__' in t
+          ? t.__multipleSources__
+          : [];
+
+    const result: Array<{ name?: string; url?: string }> = [];
+    const seen = new Set<string>();
+    for (const s of sources) {
+      const entries = s.attribution ?? topicLevel;
+      for (const entry of entries) {
+        const key = JSON.stringify(entry);
+        if (!seen.has(key)) {
+          seen.add(key);
+          result.push(entry);
+        }
+      }
+    }
+    return result.length ? result : undefined;
   }
 
   private isObject(x: unknown): x is object {
@@ -284,6 +319,11 @@ export class GeneralService {
         definition.valueMetadata = valueMetadata;
       }
 
+      const attribution = this._collectAttribution(t);
+      if (attribution) {
+        definition.attribution = attribution;
+      }
+
       if (!this.uniqueTopicsMap.has(t.title)) {
         this.uniqueTopicsMap.set(t.title, definition);
       }
@@ -315,6 +355,12 @@ export class GeneralService {
         );
         if (topicValueMetadata) {
           this.identifierValueMetadataMap.set(identifier, topicValueMetadata);
+        }
+
+        // store per-topic attribution list (fallback) if present
+        const topicAttribution = (t as topicDefinition).__attribution__;
+        if (topicAttribution && topicAttribution.length) {
+          this.identifierAttributionMap.set(identifier, topicAttribution);
         }
 
         if (t.__attributes__) {
@@ -471,6 +517,14 @@ export class GeneralService {
           if (unit) (feature.properties as any).__unit = unit;
           if (verticalDatum)
             (feature.properties as any).__verticalDatum = verticalDatum;
+
+          const topicAttribution = this.identifierAttributionMap.get(
+            result.topic,
+          );
+          const providers = source?.attribution ?? topicAttribution;
+          if (providers && providers.length) {
+            (feature.properties as any).__attribution = providers;
+          }
         });
       }
     });

--- a/src/topics/topics.service.spec.ts
+++ b/src/topics/topics.service.spec.ts
@@ -24,4 +24,32 @@ describe('TopicsService', () => {
   it('should be defined', () => {
     expect(service).toBeDefined();
   });
+
+  it('exposes attribution as a de-duplicated list for multi-source topics', () => {
+    const topics = service.getTopics();
+    const heights = topics.find((t) => t.identifiers.includes('hoehe_r'));
+    expect(heights).toBeDefined();
+    expect(heights?.attribution).toHaveLength(2);
+    expect(heights?.attribution?.[0].name).toBe('GeoSN');
+    expect(heights?.attribution?.[0].url).toContain('a3dba5b2');
+    expect(heights?.attribution?.[1].name).toBe('GeoSN');
+    expect(heights?.attribution?.[1].url).toContain('587d9a32');
+  });
+
+  it('exposes valueMetadata on topics that configure it', () => {
+    const topics = service.getTopics();
+    const heights = topics.find((t) => t.identifiers.includes('hoehe_r'));
+    expect(heights?.valueMetadata).toEqual({
+      unit: 'cm',
+      verticalDatum: 'DHHN2016',
+    });
+  });
+
+  it('omits attribution and valueMetadata on topics without configuration', () => {
+    const topics = service.getTopics();
+    const land = topics.find((t) => t.identifiers.includes('land_f'));
+    expect(land).toBeDefined();
+    expect(land?.attribution).toBeUndefined();
+    expect(land?.valueMetadata).toBeUndefined();
+  });
 });

--- a/src/topics/topics.service.spec.ts
+++ b/src/topics/topics.service.spec.ts
@@ -40,7 +40,7 @@ describe('TopicsService', () => {
     const topics = service.getTopics();
     const heights = topics.find((t) => t.identifiers.includes('hoehe_r'));
     expect(heights?.valueMetadata).toEqual({
-      unit: 'cm',
+      unit: 'm',
       verticalDatum: 'DHHN2016',
     });
   });

--- a/test/values-at-point.e2e-spec.ts
+++ b/test/values-at-point.e2e-spec.ts
@@ -115,6 +115,14 @@ describe('ValuesAtPointController (e2e)', () => {
     expect(props['__name']).toBe('gelaendehoehe_dgm');
     expect(props['__topic']).toBe('hoehe_r');
     expect(props['height']).toBe(24886);
+    expect(props['__unit']).toBe('cm');
+    expect(props['__verticalDatum']).toBe('DHHN2016');
+    expect(props['__attribution']).toEqual([
+      {
+        name: 'GeoSN',
+        url: 'https://geomis.sachsen.de/geomis-client/?lang=de#/datasets/iso/a3dba5b2-0118-4d76-ab78-ba656a1b489e',
+      },
+    ]);
 
     const geoProps = props['__geoProperties'];
     const requestProps = props['__requestParams'];
@@ -133,6 +141,14 @@ describe('ValuesAtPointController (e2e)', () => {
     expect(propsLand['__name']).toBe('oberflaechenhoehe_dom');
     expect(propsLand['__topic']).toBe('hoehe_r');
     expect(propsLand['height']).toBe(24886);
+    expect(propsLand['__unit']).toBe('cm');
+    expect(propsLand['__verticalDatum']).toBe('DHHN2016');
+    expect(propsLand['__attribution']).toEqual([
+      {
+        name: 'GeoSN',
+        url: 'https://geomis.sachsen.de/geomis-client/?lang=de#/datasets/iso/587d9a32-07ed-42dd-a207-3d0dfef7917c',
+      },
+    ]);
 
     const geoPropsLand = propsLand['__geoProperties'];
     const requestPropsLand = propsLand['__requestParams'];

--- a/topic-example.json
+++ b/topic-example.json
@@ -10,7 +10,10 @@
       "__source__": { // database source [not published for end user]
         "name": "unused",
         "source": "schmema.table_adress",
-        "srid": 4326
+        "srid": 4326,
+        "attribution": [ // optional per-source attribution, replaces __attribution__ for this source
+          { "name": "Example Provider", "url": "https://example.org/datasets/adress" }
+        ]
       },
       "__attributes__": [ // attributes to show for the end user [not published for end user]
         "title",
@@ -22,6 +25,9 @@
         "intersect",
         "within",
         "nearestNeighbour"
+      ],
+      "__attribution__": [ // optional topic-wide attribution, list of data providers
+        { "name": "Example Provider" }
       ]
     },
   ]

--- a/topic.json
+++ b/topic.json
@@ -53,12 +53,24 @@
         {
           "name": "gelaendehoehe_dgm",
           "source": "ga.dgm_r",
-          "srid": 25833
+          "srid": 25833,
+          "attribution": [
+            {
+              "name": "GeoSN",
+              "url": "https://geomis.sachsen.de/geomis-client/?lang=de#/datasets/iso/a3dba5b2-0118-4d76-ab78-ba656a1b489e"
+            }
+          ]
         },
         {
           "name": "oberflaechenhoehe_dom",
           "source": "ga.dom_r",
-          "srid": 25833
+          "srid": 25833,
+          "attribution": [
+            {
+              "name": "GeoSN",
+              "url": "https://geomis.sachsen.de/geomis-client/?lang=de#/datasets/iso/587d9a32-07ed-42dd-a207-3d0dfef7917c"
+            }
+          ]
         }
       ],
       "__attributes__": [],


### PR DESCRIPTION
## Summary

- Expose optional `valueMetadata` (unit, verticalDatum) on the `/topics` response and merge topic-level and source-level metadata per field in feature properties, so a source that overrides only one subfield (e.g. only `unit`) keeps the topic-level value for the other.
- Add optional `attribution` for data providers — a flat list of `{ name?, url? }` entries, configurable on topic level (`__attribution__`) and per source (`attribution`, fully replaces topic-level for that source). The `/topics` response exposes a de-duplicated union across sources; feature properties carry an `__attribution` scoped to the feature's source.
- Populate `hoehe_r` with per-source GeoMIS attribution (DGM + DOM) as a first real-world example.
- Document the new metadata blocks in `topics.md`.

## Test plan

- [x] `/topics` includes `valueMetadata` and `attribution` for `hoehe_r` (both blocks, union across DGM/DOM)
- [x] Topics without configuration omit both fields entirely
- [x] `valuesAtPoint` on `hoehe_r` returns `__unit`, `__verticalDatum`, and `__attribution` per feature, scoped to the source (DGM vs. DOM)
- [x] Unit tests (`topics.service.spec.ts`) and e2e tests (`values-at-point.e2e-spec.ts`) pass

Closes #159