### PR TITLE
fix(swagger): api prefix

### DIFF
--- a/src/app-init.ts
+++ b/src/app-init.ts
@@ -8,7 +8,6 @@ import { NestFastifyApplication } from '@nestjs/platform-fastify';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { SchemaObject } from '@nestjs/swagger/dist/interfaces/open-api-spec.interface';
 import fs from 'node:fs/promises';
-import path from 'node:path';
 import inputValidation, {
   ErrorDetails,
   InputValidationError,
@@ -138,7 +137,7 @@ export async function setUpOpenAPIAndValidation(
       schema.additionalProperties = schemaName.includes('Esri');
     });
 
-  SwaggerModule.setup(path.join(urlPrefix, 'api'), app, document);
+  SwaggerModule.setup('api', app, document, { useGlobalPrefix: true });
 
   // Set beautifyErrors to false for schemaPath information
   inputValidation.init(document, {


### PR DESCRIPTION
While testing #167 I stumbled upon a regression regarding the path prefixing (e.g. running all backend routes behind a /ga-Prefix). This stopped working for me in some unknown earlier merge - but only when running the dev server directly, not when building the side for use in a docker image. This did not register because we normally test using docker compose, which does build the container image.

I replaced our old custom path-building logic with the now supported `useGlobalPrefix`-Setting (see https://github.com/geobakery/GeospatialAnalyzer/blob/f546fe5cdc751d5126c59faca6b19d51355c2e0b/src/app-init.ts#L141 added in #94). This was not supported in the SwaggerModule when we initially implemented this feature. According to my tests this works in both containerized and local settings.

- [x] merge #167 which I included in here to keep testing for side effects