### PR TITLE
chore(deps): group dependabot updates and move @nestjs/cli to devDeps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,7 +33,7 @@ updates:
           - "minor"
           - "patch"
 
-  # Docker base image
+  # Container base images (Dockerfile)
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
@@ -41,10 +41,14 @@ updates:
       day: "monday"
       time: "01:00"
       timezone: "Europe/Berlin"
+    # Group minor/patch updates; majors stay as individual PRs.
     groups:
-      docker:
+      container-base-images:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
@@ -54,7 +58,11 @@ updates:
       day: "monday"
       time: "01:00"
       timezone: "Europe/Berlin"
+    # Group minor/patch updates; majors stay as individual PRs.
     groups:
       github-actions:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,60 @@
 version: 2
 updates:
-  # Enable version updates for npm
+  # npm
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
+      time: "01:00"
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 10
+    # Group minor/patch updates; majors stay as individual PRs.
+    groups:
+      # NestJS platform as one PR
+      nestjs:
+        patterns:
+          - "@nestjs/*"
+        update-types:
+          - "minor"
+          - "patch"
+      # Dev toolchain as one PR
+      dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+      # Remaining runtime deps as one PR
+      production-dependencies:
+        dependency-type: "production"
+        exclude-patterns:
+          - "@nestjs/*"
+        update-types:
+          - "minor"
+          - "patch"
 
-  # Enable version updates for Docker
+  # Docker base image
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
+      time: "01:00"
+      timezone: "Europe/Berlin"
+    groups:
+      docker:
+        patterns:
+          - "*"
 
-  # Enable version updates for GitHub Actions
+  # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "01:00"
+      timezone: "Europe/Berlin"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "packageManager": "pnpm@11.1.2",
   "dependencies": {
     "@fastify/static": "^9.1.3",
-    "@nestjs/cli": "^11.0.21",
     "@nestjs/common": "^11.1.24",
     "@nestjs/config": "^4.0.4",
     "@nestjs/core": "^11.1.24",
@@ -54,6 +53,7 @@
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",
+    "@nestjs/cli": "^11.0.21",
     "@nestjs/schematics": "^11.1.0",
     "@nestjs/testing": "^11.1.24",
     "@types/express": "^5.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,9 +19,6 @@ importers:
       '@fastify/static':
         specifier: ^9.1.3
         version: 9.1.3
-      '@nestjs/cli':
-        specifier: ^11.0.21
-        version: 11.0.21(@swc/cli@0.7.10(@swc/core@1.15.40)(chokidar@4.0.3))(@swc/core@1.15.40)(@types/node@25.9.1)(prettier@3.8.3)
       '@nestjs/common':
         specifier: ^11.1.24
         version: 11.1.24(class-transformer@0.5.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -92,6 +89,9 @@ importers:
       '@eslint/js':
         specifier: 10.0.1
         version: 10.0.1(eslint@10.4.0)
+      '@nestjs/cli':
+        specifier: ^11.0.21
+        version: 11.0.21(@swc/cli@0.7.10(@swc/core@1.15.40)(chokidar@4.0.3))(@swc/core@1.15.40)(@types/node@25.9.1)(prettier@3.8.3)
       '@nestjs/schematics':
         specifier: ^11.1.0
         version: 11.1.0(chokidar@4.0.3)(prettier@3.8.3)(typescript@5.9.3)


### PR DESCRIPTION
## Summary

- Group Dependabot npm updates into minor/patch PRs (nestjs, dev, production); majors stay individual
- Add docker and github-actions groups; all ecosystems run weekly on Monday 01:00
- Move `@nestjs/cli` to devDependencies so `pnpm prune --prod` drops it from the prod image
- Regenerate `pnpm-lock.yaml` to match