### PR TITLE
chore(lint): ignore generated coverage output

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,7 +4,11 @@ import eslintConfigPrettier from 'eslint-config-prettier';
 
 export default [
   {
-    ignores: ['dist/**', 'test/common/big_geojson_coordinate.json'],
+    ignores: [
+      'dist/**',
+      'coverage/**',
+      'test/common/big_geojson_coordinate.json',
+    ],
   },
   eslint.configs.recommended,
   ...tseslint.configs.recommended,


### PR DESCRIPTION
## Summary

Excludes the generated Jest coverage output from ESLint, so `pnpm lint` no longer fails locally when a coverage report is present.

When `coverage/` exists locally (e.g. after running tests with coverage), `pnpm lint` picks up the generated reports (`coverage/lcov-report/*.js`) and fails with parsing errors, since those files aren't part of the TypeScript project config.

Added `coverage/**` to the ESLint ignore list. `coverage/` is gitignored anyway.
