### PR TITLE
ci: add PR checks (lint, format, build, unit tests)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded runs on PRs, but let every push to main finish
+  # so each commit on main keeps a complete CI result.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgis/postgis:15-3.4
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: geobakery
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+        # Version is read from the "packageManager" field in package.json
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm ci
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Check formatting
+        run: pnpm format:check
+
+      - name: Build
+        run: pnpm build
+
+      - name: Test
+        run: pnpm test


### PR DESCRIPTION
Adds a CI workflow that runs on PRs and pushes to `main`: `pnpm ci`, `lint`, `format:check`, `build`, and `unit tests`.

A `postgis` service container is included because the unit tests open a real DB connection through NestJS dependency injection (the services require a `DataSource`), even though they read no data.
A concurrency group cancels superseded PR runs, while pushes to `main` are left to finish.

Follow-up in a separate PR: mock `DataSource` in the affected specs so the unit tests no longer need a database, then drop the service from CI. e2e is left out for now; it needs the dataset dump restored plus PostGIS extensions in its own job.

Part of #149