### PR TITLE
ci: add e2e tests to PR checks (postgis restore + test:e2e)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,9 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  test:
+  checks:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     services:
       postgres:
@@ -61,5 +62,29 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Test
+      - name: Unit tests
         run: pnpm test
+
+      # Restore into a dedicated fresh DB via the matched pg15 client from the
+      # postgis image, NOT the image's default "postgres" DB: that one ships
+      # with postgis_topology + postgis_tiger_geocoder, whose tiger/topology
+      # schemas collide with the dump's CREATE SCHEMA statements. The e2e step
+      # targets this DB via the env override below.
+      - name: Restore test database
+        run: |
+          docker run --rm --network host \
+            -e PGPASSWORD=geobakery \
+            -v "$PWD/sql/data:/tmp/data:ro" \
+            postgis/postgis:15-3.4 \
+            bash -c '
+              set -e
+              createdb -h localhost -U postgres ga
+              psql -h localhost -U postgres -d ga -v ON_ERROR_STOP=1 \
+                -c "CREATE EXTENSION IF NOT EXISTS postgis; CREATE EXTENSION IF NOT EXISTS postgis_raster;"
+              pg_restore -h localhost -U postgres -d ga --no-owner /tmp/data
+            '
+
+      - name: E2E tests
+        env:
+          GEOSPATIAL_ANALYZER_DB_DATABASE: ga
+        run: pnpm test:e2e


### PR DESCRIPTION
Adds the e2e suite to the PR checks.

- Restore the committed `sql/data` dump into the postgis service via the pinned `postgis/postgis:15-3.4` image (client == server == dump origin), then run `pnpm test:e2e`, giving PRs real coverage for the geo operations, including Dependabot dependency bumps.
- Rename the job from "test" to "checks" (it runs lint/format/build alongside the unit and e2e tests).
- Add a 15-minute job timeout.

Validated locally against a fresh PostGIS 15 (clean `pg_restore`, 37/37 e2e). CI is green.

Part of #149