### PR TITLE
fix(general): detect SQL timeouts by SQLSTATE instead of message text

### DIFF
--- a/src/general/general.constants.ts
+++ b/src/general/general.constants.ts
@@ -51,8 +51,18 @@ export const QUERY_FEATURE_INDEX = 'feature_wkt_';
 export const HTTP_STATUS_SQL_TIMEOUT = HttpStatus.UNPROCESSABLE_ENTITY;
 
 /**
- * SQLSTATE `query_canceled`, reported when `statement_timeout` cancels a
- * statement. Postgres localises error messages via `lc_messages`, so the
- * SQLSTATE is the only server-independent way to recognise a timeout.
+ * SQLSTATE `query_canceled`. It marks a statement as cancelled but says nothing
+ * about why - the service issues no cancel requests itself, so a timeout is the
+ * likeliest cause, but an outside `pg_cancel_backend()` is indistinguishable.
+ *
+ * Postgres localises error messages via `lc_messages`, which is why the SQLSTATE
+ * and not the text is the thing to match on.
  */
 export const SQLSTATE_QUERY_CANCELED = '57014';
+
+/**
+ * Message thrown by node-postgres' own `query_timeout`. It fires client-side, so
+ * the error carries no SQLSTATE and only the text is left to match - it comes
+ * from the driver, not from Postgres, and is never localised.
+ */
+export const PG_CLIENT_READ_TIMEOUT_MESSAGE = 'Query read timeout';

--- a/src/general/general.constants.ts
+++ b/src/general/general.constants.ts
@@ -49,3 +49,10 @@ export const QUERY_FEATURE_INDEX = 'feature_wkt_';
  *   that the situation is temporary and somewhat easily fixable.
  */
 export const HTTP_STATUS_SQL_TIMEOUT = HttpStatus.UNPROCESSABLE_ENTITY;
+
+/**
+ * SQLSTATE `query_canceled`, reported when `statement_timeout` cancels a
+ * statement. Postgres localises error messages via `lc_messages`, so the
+ * SQLSTATE is the only server-independent way to recognise a timeout.
+ */
+export const SQLSTATE_QUERY_CANCELED = '57014';

--- a/src/general/general.service.spec.ts
+++ b/src/general/general.service.spec.ts
@@ -1,6 +1,17 @@
+import { HttpStatus } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import { QueryFailedError, SelectQueryBuilder } from 'typeorm';
 import { TransformModule } from '../transform/transform.module';
-import { GeneralService } from './general.service';
+import {
+  GeneralService,
+  GeospatialRequest,
+  GeospatialResultEntity,
+} from './general.service';
+import {
+  HTTP_STATUS_SQL_TIMEOUT,
+  PG_CLIENT_READ_TIMEOUT_MESSAGE,
+  SQLSTATE_QUERY_CANCELED,
+} from './general.constants';
 import { topicDefinition } from './general.interface';
 import { ConfigModule } from '@nestjs/config';
 
@@ -118,6 +129,79 @@ describe('GeneralService', () => {
         const result = service.getTopics();
         expect(result).toEqual(['topicB']);
       });
+    });
+  });
+
+  describe('error mapping in calculateMethode', () => {
+    beforeAll(async () => await setup());
+    afterAll(async () => await mod.close());
+
+    const REQUEST: GeospatialRequest = {
+      topics: ['topicA'],
+      inputGeometries: [
+        {
+          type: 'Feature',
+          geometry: { type: 'Point', coordinates: [13.75, 51.07] },
+          properties: {},
+        },
+      ],
+      outputFormat: 'geojson',
+      outSRS: 4326,
+      returnGeometry: false,
+    };
+
+    /**
+     * Rebuilds what TypeORM does with a failing query. Hand-built on purpose:
+     * only this way can message and SQLSTATE be varied independently, which is
+     * what the mapping must not depend on.
+     */
+    function queryBuilderRejectingWith(driverError: Error) {
+      return {
+        getRawMany: () =>
+          Promise.reject(new QueryFailedError('select 1', [], driverError)),
+      } as unknown as SelectQueryBuilder<GeospatialResultEntity>;
+    }
+
+    it('maps a cancelled statement to the timeout status whatever language the message is in', async () => {
+      // What a server with a German lc_messages reports - no "timeout" in it.
+      const driverError = Object.assign(
+        new Error('storniere Anfrage wegen Zeitüberschreitung der Anfrage'),
+        { code: SQLSTATE_QUERY_CANCELED },
+      );
+
+      await expect(
+        service.calculateMethode(
+          REQUEST,
+          queryBuilderRejectingWith(driverError),
+        ),
+      ).rejects.toMatchObject({ status: HTTP_STATUS_SQL_TIMEOUT });
+    });
+
+    it("maps the driver's client-side read timeout to the timeout status", async () => {
+      // Fires before the statement reaches the server, hence no SQLSTATE.
+      const driverError = new Error(PG_CLIENT_READ_TIMEOUT_MESSAGE);
+
+      await expect(
+        service.calculateMethode(
+          REQUEST,
+          queryBuilderRejectingWith(driverError),
+        ),
+      ).rejects.toMatchObject({ status: HTTP_STATUS_SQL_TIMEOUT });
+    });
+
+    it('maps an unrelated query failure to a server error even if its message mentions a timeout', async () => {
+      // Mentions a timeout without being one; a loose message match misreports it.
+      const driverError = Object.assign(
+        new Error('column "timeout" does not exist'),
+        { code: '42703' },
+      );
+
+      await expect(
+        service.calculateMethode(
+          REQUEST,
+          queryBuilderRejectingWith(driverError),
+        ),
+      ).rejects.toMatchObject({ status: HttpStatus.INTERNAL_SERVER_ERROR });
     });
   });
 });

--- a/src/general/general.service.ts
+++ b/src/general/general.service.ts
@@ -20,6 +20,7 @@ import {
   HTTP_STATUS_SQL_TIMEOUT,
   STANDARD_CRS,
   SOURCE_NAME_PROPERTY,
+  SQLSTATE_QUERY_CANCELED,
   supportedDatabase,
 } from './general.constants';
 import {
@@ -593,12 +594,7 @@ export class GeneralService {
         throw e;
       }
 
-      if (
-        e instanceof QueryFailedError &&
-        (e.message === 'Query read timeout' ||
-          e.message.includes('canceling statement due to statement timeout') ||
-          e.message.includes('timeout'))
-      ) {
+      if (e instanceof QueryFailedError && this.isTimeoutError(e)) {
         throw new HttpException(
           'The request cannot be processed in a timely manner',
           HTTP_STATUS_SQL_TIMEOUT,
@@ -608,6 +604,23 @@ export class GeneralService {
       // Fallback: Any other error is unknown/unexpected, so a generic 500 must suffice.
       throw new HttpException(e, HttpStatus.INTERNAL_SERVER_ERROR);
     }
+  }
+
+  /**
+   * Recognises a statement that was cancelled for running too long.
+   *
+   * The SQLSTATE is the reliable signal: `message` is derived from the driver
+   * error, and Postgres localises that text via `lc_messages`. The message
+   * checks remain as a fallback for client-side timeouts, which never reach the
+   * server and therefore carry no SQLSTATE.
+   */
+  private isTimeoutError(e: QueryFailedError): boolean {
+    const sqlState = (e.driverError as { code?: string } | undefined)?.code;
+    if (sqlState === SQLSTATE_QUERY_CANCELED) {
+      return true;
+    }
+
+    return e.message === 'Query read timeout' || e.message.includes('timeout');
   }
 
   /**

--- a/src/general/general.service.ts
+++ b/src/general/general.service.ts
@@ -18,6 +18,7 @@ import {
   ESRIJSON_PARAMETER,
   GEOJSON_PARAMETER,
   HTTP_STATUS_SQL_TIMEOUT,
+  PG_CLIENT_READ_TIMEOUT_MESSAGE,
   STANDARD_CRS,
   SOURCE_NAME_PROPERTY,
   SQLSTATE_QUERY_CANCELED,
@@ -607,12 +608,9 @@ export class GeneralService {
   }
 
   /**
-   * Recognises a statement that was cancelled for running too long.
-   *
-   * The SQLSTATE is the reliable signal: `message` is derived from the driver
-   * error, and Postgres localises that text via `lc_messages`. The message
-   * checks remain as a fallback for client-side timeouts, which never reach the
-   * server and therefore carry no SQLSTATE.
+   * Recognises a statement that was cancelled for running too long - by the
+   * server, or by the driver's own read timeout. Both constants document why
+   * they are matched the way they are.
    */
   private isTimeoutError(e: QueryFailedError): boolean {
     const sqlState = (e.driverError as { code?: string } | undefined)?.code;
@@ -620,7 +618,7 @@ export class GeneralService {
       return true;
     }
 
-    return e.message === 'Query read timeout' || e.message.includes('timeout');
+    return e.message === PG_CLIENT_READ_TIMEOUT_MESSAGE;
   }
 
   /**

--- a/test/timeout.e2e-spec.ts
+++ b/test/timeout.e2e-spec.ts
@@ -1,0 +1,73 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DataSource, QueryFailedError, SelectQueryBuilder } from 'typeorm';
+import {
+  HTTP_STATUS_SQL_TIMEOUT,
+  SQLSTATE_QUERY_CANCELED,
+} from '../src/general/general.constants';
+import { GeneralModule } from '../src/general/general.module';
+import { GeneralService } from '../src/general/general.service';
+import { TransformModule } from '../src/transform/transform.module';
+import { createTestModules } from './helpers/database.helper';
+
+/**
+ * Covers the mapping from a cancelled statement to the dedicated timeout status
+ * in GeneralService.calculateMethode. The error has to come from the driver: a
+ * hand-built QueryFailedError would satisfy the service's instanceof check by
+ * construction.
+ */
+describe('SQL timeout handling (e2e)', () => {
+  let moduleFixture: TestingModule;
+
+  beforeAll(async () => {
+    moduleFixture = await Test.createTestingModule({
+      imports: [
+        // 1 ms is below any real query's runtime, so the cancellation is
+        // deterministic instead of the test racing a threshold.
+        ...createTestModules([], { statementTimeout: 1 }),
+        GeneralModule,
+        TransformModule,
+      ],
+    }).compile();
+    await moduleFixture.init();
+  });
+
+  afterAll(async () => {
+    await moduleFixture.close();
+  });
+
+  it('maps a statement cancelled by the database to the timeout status', async () => {
+    const dataSource = moduleFixture.get(DataSource);
+    const generalService = moduleFixture.get(GeneralService);
+
+    const failingQueryBuilder = dataSource
+      .createQueryBuilder()
+      .select('pg_sleep(2)')
+      .from('(select 1)', 'delay') as unknown as SelectQueryBuilder<never>;
+
+    // Asserted on the SQLSTATE, not the message: Postgres localises error text.
+    await expect(failingQueryBuilder.getRawMany()).rejects.toBeInstanceOf(
+      QueryFailedError,
+    );
+    await expect(failingQueryBuilder.getRawMany()).rejects.toMatchObject({
+      driverError: { code: SQLSTATE_QUERY_CANCELED },
+    });
+
+    const request = {
+      topics: ['kreis_f'],
+      inputGeometries: [
+        {
+          type: 'Feature',
+          geometry: { type: 'Point', coordinates: [13.75, 51.07] },
+          properties: {},
+        },
+      ],
+      outputFormat: 'geojson',
+      outSRS: 4326,
+      returnGeometry: false,
+    };
+
+    await expect(
+      generalService.calculateMethode(request as never, failingQueryBuilder),
+    ).rejects.toMatchObject({ status: HTTP_STATUS_SQL_TIMEOUT });
+  });
+});

--- a/test/timeout.e2e-spec.ts
+++ b/test/timeout.e2e-spec.ts
@@ -5,15 +5,26 @@ import {
   SQLSTATE_QUERY_CANCELED,
 } from '../src/general/general.constants';
 import { GeneralModule } from '../src/general/general.module';
-import { GeneralService } from '../src/general/general.service';
+import {
+  GeneralService,
+  GeospatialResultEntity,
+} from '../src/general/general.service';
 import { TransformModule } from '../src/transform/transform.module';
+import { GEOJSON_WITHOUT_GEOMETRY_KREIS } from './common/constants';
 import { createTestModules } from './helpers/database.helper';
 
 /**
- * Covers the mapping from a cancelled statement to the dedicated timeout status
- * in GeneralService.calculateMethode. The error has to come from the driver: a
- * hand-built QueryFailedError would satisfy the service's instanceof check by
- * construction.
+ * Pins down the contract this service relies on but cannot control: that a
+ * statement cancelled by the database really does arrive as SQLSTATE 57014.
+ * Only a real driver error can show that, which is why this runs against a
+ * database instead of a hand-built QueryFailedError.
+ *
+ * The complementary half - that the mapping keys off the SQLSTATE and not off
+ * the message, whose language depends on the server's lc_messages - lives in
+ * src/general/general.service.spec.ts, where the error can be varied freely.
+ * The client-side read timeout is only covered there: pinning it against a real
+ * driver needs a second connection pool, which leaks when torn down while the
+ * abandoned statement still runs.
  */
 describe('SQL timeout handling (e2e)', () => {
   let moduleFixture: TestingModule;
@@ -42,32 +53,26 @@ describe('SQL timeout handling (e2e)', () => {
     const failingQueryBuilder = dataSource
       .createQueryBuilder()
       .select('pg_sleep(2)')
-      .from('(select 1)', 'delay') as unknown as SelectQueryBuilder<never>;
+      .from(
+        '(select 1)',
+        'delay',
+      ) as unknown as SelectQueryBuilder<GeospatialResultEntity>;
 
-    // Asserted on the SQLSTATE, not the message: Postgres localises error text.
-    await expect(failingQueryBuilder.getRawMany()).rejects.toBeInstanceOf(
-      QueryFailedError,
-    );
-    await expect(failingQueryBuilder.getRawMany()).rejects.toMatchObject({
-      driverError: { code: SQLSTATE_QUERY_CANCELED },
+    const driverFailure: unknown = await failingQueryBuilder
+      .getRawMany()
+      .catch((e: unknown) => e);
+
+    expect(driverFailure).toBeInstanceOf(QueryFailedError);
+    // Asserted on the SQLSTATE, not the message: Postgres localises the text.
+    expect((driverFailure as QueryFailedError).driverError).toMatchObject({
+      code: SQLSTATE_QUERY_CANCELED,
     });
 
-    const request = {
-      topics: ['kreis_f'],
-      inputGeometries: [
-        {
-          type: 'Feature',
-          geometry: { type: 'Point', coordinates: [13.75, 51.07] },
-          properties: {},
-        },
-      ],
-      outputFormat: 'geojson',
-      outSRS: 4326,
-      returnGeometry: false,
-    };
-
     await expect(
-      generalService.calculateMethode(request as never, failingQueryBuilder),
+      generalService.calculateMethode(
+        GEOJSON_WITHOUT_GEOMETRY_KREIS(),
+        failingQueryBuilder,
+      ),
     ).rejects.toMatchObject({ status: HTTP_STATUS_SQL_TIMEOUT });
   });
 });


### PR DESCRIPTION
## Problem

`GeneralService.calculateMethode` recognised SQL timeouts by matching the error message. `QueryFailedError.message` comes from `driverError.toString()`, and Postgres localises its messages via `lc_messages`, so on a non-English server none of the checks matched and a cancelled statement was reported as 500 instead of 422.

Reproduced against a local instance:

```
lc_messages = German_Germany.1252
SQLSTATE     = 57014
message      = "storniere Anfrage wegen Zeitüberschreitung der Anfrage"
```

Neither the English wording nor the substring `timeout` occurs in it. CI runs an English locale, so the bug is invisible there.

## Fix

Match SQLSTATE `57014` (`query_canceled`). The message checks stay as a fallback for the driver's client-side `Query read timeout`, which never reaches the server and carries no SQLSTATE. Purely additive: no case that returned 422 before can now return 500.

## Test

`test/timeout.e2e-spec.ts` has the database cancel a real statement at `statement_timeout = 1 ms` and routes the driver error through `calculateMethode`. The error has to come from the driver: a hand-built `QueryFailedError` would satisfy the `instanceof` check by construction.

Verified against typeorm 0.3.30 (this branch) and 1.1.0.